### PR TITLE
arista: Change executable name to cspr

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ allow for a series of code reviews of interdependent code.
 
 spr is pronounced /ˈsuːpəɹ/, like the English word 'super'.
 
+## Changes specific to `github.com/aristanetworks/cordspr`
+
+Rename executable to `cspr`.  There are several "stacked pull request" tools in existence;
+change the name to avoid at least some conflicts ("c" for "cord").
+
 ## Documentation
 
 Comprehensive documentation is available here: https://getcord.github.io/spr/

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 edition = "2021"
 exclude = [".github", ".gitignore"]
 
+[[bin]]
+name = "cspr"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "^3.2.6", features = ["derive", "wrap_help"] }
 console = "^0.15.0"


### PR DESCRIPTION
There are several tools called `spr`.  Rename to avoid conflicting
with other tools which may also be installed ("c" for "cord").
