### PR TITLE
arista: Add spr.addReviewedBy default false

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ allow for a series of code reviews of interdependent code.
 
 spr is pronounced /ˈsuːpəɹ/, like the English word 'super'.
 
+## Changes specific to `github.com/aristanetworks/cordspr`
+
+Rename executable to `cspr`.  There are several "stacked pull request" tools in existence;
+change the name to avoid at least some conflicts ("c" for "cord").
+
+### Configuration
+
+There are several changes and additions to the configuration settings stored in `.git/config`
+in the `[spr]` section.
+
+#### requireTestPlan
+
+Change the default from `true` to `false`.
+
 ## Documentation
 
 Comprehensive documentation is available here: https://getcord.github.io/spr/

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 edition = "2021"
 exclude = [".github", ".gitignore"]
 
+[[bin]]
+name = "cspr"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "^3.2.6", features = ["derive", "wrap_help"] }
 console = "^0.15.0"

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -134,7 +134,7 @@ pub async fn spr() -> Result<()> {
     let require_test_plan = git_config
         .get_bool("spr.requireTestPlan")
         .ok()
-        .unwrap_or(true);
+        .unwrap_or(false);
 
     let config = spr::config::Config::new(
         github_owner,


### PR DESCRIPTION
Add a config option to enable/disable adding "Reviewed-By" to the
commit message, and set its default to false.
The previous behavior was to always add it.
