### PR TITLE
arista: Add spr.autoUpdateMessage default true

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@ allow for a series of code reviews of interdependent code.
 
 spr is pronounced /ˈsuːpəɹ/, like the English word 'super'.
 
+## Changes specific to `github.com/aristanetworks/cordspr`
+
+### Miscellaneous
+
+- Rename executable to `cspr`.  There are several "stacked pull request" tools in existence;
+change the name to avoid at least some conflicts ("c" for "cord").
+- When summarizing diffs, require the user to enter `ABORT` instead of ampty string to abort.
+Change message to "No description" if none is entered.
+
+### Configuration
+
+There are several changes and additions to the configuration settings stored in `.git/config`
+in the `[spr]` section.
+
+#### requireTestPlan
+
+Change the default from `true` to `false`.
+
+#### addReviewedBy
+
+Add a configuration setting to control adding `Reviewed-By` trailers to commit messages.
+Change the default from `true` to `false`.
+
 ## Documentation
 
 Comprehensive documentation is available here: https://getcord.github.io/spr/

--- a/spr/Cargo.toml
+++ b/spr/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 edition = "2021"
 exclude = [".github", ".gitignore"]
 
+[[bin]]
+name = "cspr"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "^3.2.6", features = ["derive", "wrap_help"] }
 console = "^0.15.0"

--- a/spr/src/commands/diff.rs
+++ b/spr/src/commands/diff.rs
@@ -481,12 +481,12 @@ async fn diff_impl(
 
     let mut github_commit_message = opts.message.clone();
     if pull_request.is_some() && github_commit_message.is_none() {
-        let input = {
+        let mut input = {
             let message_on_prompt = message_on_prompt.clone();
 
             tokio::task::spawn_blocking(move || {
                 dialoguer::Input::<String>::new()
-                    .with_prompt("Message (leave empty to abort)")
+                    .with_prompt("Message (ABORT to abort)")
                     .with_initial_text(message_on_prompt)
                     .allow_empty(true)
                     .interact_text()
@@ -494,8 +494,11 @@ async fn diff_impl(
             .await??
         };
 
-        if input.is_empty() {
+        if input.eq("ABORT") {
             return Err(Error::new("Aborted as per user request".to_string()));
+        }
+        if input.is_empty() {
+            input = "No description".to_string()
         }
 
         *message_on_prompt = input.clone();

--- a/spr/src/config.rs
+++ b/spr/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub branch_prefix: String,
     pub require_approval: bool,
     pub require_test_plan: bool,
+    pub add_reviewed_by: bool,
 }
 
 impl Config {
@@ -29,6 +30,7 @@ impl Config {
         branch_prefix: String,
         require_approval: bool,
         require_test_plan: bool,
+        add_reviewed_by: bool,
     ) -> Self {
         let master_ref = GitHubBranch::new_from_branch_name(
             &master_branch,
@@ -43,6 +45,7 @@ impl Config {
             branch_prefix,
             require_approval,
             require_test_plan,
+            add_reviewed_by,
         }
     }
 
@@ -155,6 +158,7 @@ mod tests {
             "master".into(),
             "spr/foo/".into(),
             false,
+            true,
             true,
         )
     }

--- a/spr/src/main.rs
+++ b/spr/src/main.rs
@@ -134,7 +134,11 @@ pub async fn spr() -> Result<()> {
     let require_test_plan = git_config
         .get_bool("spr.requireTestPlan")
         .ok()
-        .unwrap_or(true);
+        .unwrap_or(false);
+    let add_reviewed_by = git_config
+        .get_bool("spr.addReviewedBy")
+        .ok()
+        .unwrap_or(false);
 
     let config = spr::config::Config::new(
         github_owner,
@@ -144,6 +148,7 @@ pub async fn spr() -> Result<()> {
         branch_prefix,
         require_approval,
         require_test_plan,
+        add_reviewed_by,
     );
 
     let git = spr::git::Git::new(repo);


### PR DESCRIPTION
Add a config message to default to always updating the github
title + message from the commit.

This differs from the previous default, which warned the user
that the PR and the commit message are out-of-sync, requiring
the user to run manual steps to update in either direction.
